### PR TITLE
RP-83 Design: 메인 페이지 SearchBar 부근 여백 조정

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -62,7 +62,7 @@ const SortRow = styled.div`
     display: flex;
     justify-content: flex-end;
     flex-wrap: wrap;
-    margin-top: ${({ theme }) => theme.spacing[8]};
+    margin-top: ${({ theme }) => theme.spacing[6]};
     margin-bottom: ${({ theme }) => theme.spacing[4]};
 `;
 

--- a/src/pages/main/MainSearchBar.tsx
+++ b/src/pages/main/MainSearchBar.tsx
@@ -146,7 +146,6 @@ const SearchContainer = styled.div`
     flex-direction: column;
     gap: ${({ theme }) => theme.spacing[6]};
     width: 100%;
-    height: 5.5rem;
 `;
 
 const RecentSearchWrapper = styled.div`
@@ -154,6 +153,7 @@ const RecentSearchWrapper = styled.div`
     flex-direction: row;
     gap: ${({ theme }) => theme.spacing[3]};
     height: 1rem;
+    padding-bottom: ${({ theme }) => theme.spacing[2]}
     font-size: ${({ theme }) => theme.typography.size.sm};
     color: ${({ theme }) => theme.colors.content.sub};
 `;


### PR DESCRIPTION
## 🔥 관련 이슈

- Jira 이슈: [RP-83](https://cherrypick-devteam.atlassian.net/browse/RP-83)

<br/>

## 📝 변경사항

- [x] 최근 검색어의 유무에 따라 검색 창이 차지하는 공간을 변동하도록 수정했습니다.

<br/>

## 📷 스크린샷 (선택)
>
Before
![image](https://github.com/user-attachments/assets/af2afad0-5a01-4abf-affe-10eab7622f73)

After
![image](https://github.com/user-attachments/assets/86db6f85-add3-4d62-a9a2-043f83782c67)


<br/>

## 📋 체크리스트

- [x] Jira 이슈와 연결함
- [x] 테스트 코드를 작성했거나, 충분히 테스트했음
- [x] PR 내용과 커밋 메시지에 이슈 키 포함

<br/>

---


🙌 봐주세요! :
> 
