### PR TITLE
RP-95 API Client 구현

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+// import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 
@@ -9,12 +9,12 @@ import { OverlayProvider } from './context/overlay';
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-        <QueryClientProvider client={queryClient}>
-            <OverlayProvider>
-                <App />
-                <ReactQueryDevtools initialIsOpen={false} />
-            </OverlayProvider>
-        </QueryClientProvider>
-    </React.StrictMode>,
+    // <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+        <OverlayProvider>
+            <App />
+            <ReactQueryDevtools initialIsOpen={false} />
+        </OverlayProvider>
+    </QueryClientProvider>,
+    // </React.StrictMode>,
 );

--- a/src/pages/product-detail/ProductDetailPage.tsx
+++ b/src/pages/product-detail/ProductDetailPage.tsx
@@ -1,20 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from 'react-router-dom';
 
 import DefaultLayout from '@/components/layout/DefaultLayout';
-import ProductTopSection from "./ProductTopSection";
-import ProductComments from "../../components/detail/ProductComment";
-import ProductRecommend from "../../components/detail/ProductRecommend";
+import ProductTopSection from './ProductTopSection';
+import ProductComments from '../../components/detail/ProductComment';
+import ProductRecommend from '../../components/detail/ProductRecommend';
 import BestCommentList from '@/components/detail/ProductComment/BestCommentList';
-import styled from "styled-components";
+import styled from 'styled-components';
 import { LoadingSpinner } from '@/components/common/Loading/LoadingSpinner';
 
 import { fetchDetailedDeal } from '@/services/apiDeal';
 import { fetchCommentsByDealId, fetchBestCommentsByDealId } from '@/services/apiComment';
 import { Comment, BestComment } from '@/types/Comment';
+import { useEffect } from 'react';
 
 function ProductDetailPage() {
     const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
 
     const {
         data: deal,
@@ -24,26 +26,27 @@ function ProductDetailPage() {
         queryKey: ['deal', id],
         queryFn: () => fetchDetailedDeal(id!),
         enabled: !!id,
+        retry: false,
     });
 
-    const {
-        data: comments,
-        isLoading: isLoadingComments,
-    } = useQuery<Comment[]>({
+    const { data: comments, isLoading: isLoadingComments } = useQuery<Comment[]>({
         queryKey: ['comments', id],
         queryFn: () => fetchCommentsByDealId(id!, 'LATEST'),
         enabled: !!id,
         retry: false,
     });
 
-    const {
-        data: bestComments,
-        isLoading: isLoadingBestComments,
-    } = useQuery<BestComment[]>({
+    const { data: bestComments, isLoading: isLoadingBestComments } = useQuery<BestComment[]>({
         queryKey: ['bestComments', id],
         queryFn: () => fetchBestCommentsByDealId(id!),
         enabled: !!id,
     });
+
+    useEffect(() => {
+        if (isErrorDeal) {
+            navigate('/');
+        }
+    }, [isErrorDeal, navigate]);
 
     if (isLoadingDeal || isLoadingComments || isLoadingBestComments) {
         return <LoadingSpinner />;
@@ -62,13 +65,8 @@ function ProductDetailPage() {
                 </RecommendWrapper>
 
                 <CommentContainer>
-                    {bestComments && bestComments.length > 0 && (
-                        <BestCommentList bestComments={bestComments} />
-                    )}
-                    <ProductComments
-                        initialComments={comments ?? []}
-                        dealId={id!}
-                    />
+                    {bestComments && bestComments.length > 0 && <BestCommentList bestComments={bestComments} />}
+                    <ProductComments initialComments={comments ?? []} dealId={id!} />
                 </CommentContainer>
             </SubContainer>
         </DefaultLayout>

--- a/src/pages/product-upload/ProductUploadPage.tsx
+++ b/src/pages/product-upload/ProductUploadPage.tsx
@@ -100,14 +100,9 @@ export default function ProductUploadPage() {
             discountDescription: deal.discountDescription,
         };
 
-        uploadDeal(uploadDealData)
-            .then(() => {
-                navigate('/');
-            })
-            .catch(error => {
-                alert('핫딜 게시글 작성 실패');
-                console.error(error);
-            });
+        uploadDeal(uploadDealData).then(() => {
+            navigate('/');
+        });
     };
 
     // 유효성 검사

--- a/src/services/apiCategory.ts
+++ b/src/services/apiCategory.ts
@@ -7,11 +7,10 @@ interface fetchCategoriesResponse {
 }
 
 export async function fetchCategories(): Promise<Category[]> {
-    try {
-        const res = await publicRequest<fetchCategoriesResponse>(HttpMethod.GET, '/category');
-        return res.categories;
-    } catch (error) {
-        console.error('카테고리 조회 실패:', error);
-        throw error;
+    const result = await publicRequest<fetchCategoriesResponse>(HttpMethod.GET, '/category');
+    if (result.success) {
+        return result.data.categories;
+    } else {
+        return [];
     }
 }

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { AccessTokenType, APIException, HttpMethod, ResponseData } from '@/types/Api';
 import { AccessTokenService } from './accessTokenService';
 
@@ -7,6 +7,32 @@ const apiUrl = import.meta.env.VITE_API_URL || null;
 if (!apiUrl) {
     alert('서비스 환경이 올바르게 설정되지 않았습니다. 잠시 후 다시 시도해주세요.');
     throw new Error('환경변수(API URL)가 설정되지 않았습니다.');
+}
+
+interface ErrorHandlingOptions {
+    silent?: boolean;
+    customMessage?: string;
+}
+
+type Result<T, E = APIException> = { success: true; data: T } | { success: false; error: E };
+
+class GlobalErrorHandler {
+    private static instance: GlobalErrorHandler;
+
+    static getInstance() {
+        if (!GlobalErrorHandler.instance) {
+            GlobalErrorHandler.instance = new GlobalErrorHandler();
+        }
+        return GlobalErrorHandler.instance;
+    }
+
+    handleError(error: APIException, options: ErrorHandlingOptions = {}) {
+        // 사일런트 모드가 아니면 알림 표시
+        if (!options.silent) {
+            const message = options.customMessage || error.message || 'API 오류가 발생했습니다.';
+            alert(message); // 실제로는 toast 사용 권장
+        }
+    }
 }
 
 // 인증이 필요 없는 공개 API용 axios 인스턴스
@@ -31,7 +57,6 @@ const authApiClient = axios.create({
 /**
  * 인증이 필요한 요청에 대한 인터셉터 설정
  * - 요청 시 Authorization 헤더 자동 추가
- * - 요청/응답/에러 콘솔 로깅
  */
 authApiClient.interceptors.request.use(
     (config: InternalAxiosRequestConfig) => {
@@ -39,59 +64,58 @@ authApiClient.interceptors.request.use(
         if (token) {
             config.headers.Authorization = `Bearer ${token}`;
         }
-        // console.log('[Auth Request]', config.method?.toUpperCase(), config.url, config);
         return config;
     },
     error => {
-        console.error('[Auth Request Error]', error);
-        return Promise.reject(error);
-    },
-);
-
-authApiClient.interceptors.response.use(
-    (response: AxiosResponse) => {
-        // console.log('[Auth Response]', response.status, response.data);
-        return response;
-    },
-    (error: AxiosError) => {
-        console.error('[Auth API Error]', error);
         return Promise.reject(error);
     },
 );
 
 /**
- * 공통 에러 핸들러
+ * 공통 에러 핸들러 - 개발 모드에서만 로깅
  * @param {AxiosError} error - Axios 오류 객체
  * @returns {APIException} - 처리된 오류 객체
  */
-function handleError(error: AxiosError) {
+function handleError(error: AxiosError): APIException {
     if (error.response) {
         const responseData = error.response.data as ResponseData<null>;
-        console.error('[API Error]', error.response.status, responseData?.message);
+
+        // 개발 모드에서만 콘솔 로깅
+        if (process.env.NODE_ENV === 'development') {
+            console.error('[API Error]', error.response.status, responseData?.message);
+        }
+
         return new APIException(error.response.status, responseData?.message || 'API Error');
     } else if (error.request) {
-        console.error('[Network Error]', error.message);
+        if (process.env.NODE_ENV === 'development') {
+            console.error('[Network Error]', error.message);
+        }
         return new APIException(0, 'Network error');
     } else {
-        console.error('[Unknown Error]', error.message);
+        if (process.env.NODE_ENV === 'development') {
+            console.error('[Unknown Error]', error.message);
+        }
         return new APIException(-1, 'Unknown error');
     }
 }
 
 /**
- * 인증이 필요한 API 요청 함수
+ * 인증이 필요한 API 요청 함수 - Result 패턴 적용
  * @template T - 반환할 데이터 타입
  * @param {HttpMethod} method - HTTP 메서드
  * @param {string} url - 요청할 엔드포인트 URL
  * @param {unknown} [data] - 요청 바디 데이터 (선택적)
- * @returns {Promise<T>} - API 응답 데이터
+ * @param {Record<string, unknown>} [config] - axios 설정 (선택적)
+ * @param {ErrorHandlingOptions} [errorOptions] - 에러 처리 옵션 (선택적)
+ * @returns {Promise<Result<T>>} - 성공/실패 정보를 포함한 결과
  */
 export async function authRequest<T>(
     method: HttpMethod,
     url: string,
     data?: unknown,
     config?: Record<string, unknown>,
-): Promise<T> {
+    errorOptions?: ErrorHandlingOptions,
+): Promise<Result<T>> {
     try {
         const response = await authApiClient.request<T>({
             method,
@@ -99,26 +123,34 @@ export async function authRequest<T>(
             data,
             ...config,
         });
-        return response.data;
+
+        return { success: true, data: response.data };
     } catch (error) {
-        return Promise.reject(handleError(error as AxiosError));
+        const apiError = handleError(error as AxiosError);
+
+        GlobalErrorHandler.getInstance().handleError(apiError, errorOptions);
+
+        return { success: false, error: apiError };
     }
 }
 
 /**
- * 인증이 필요 없는 API 요청 함수
+ * 인증이 필요 없는 API 요청 함수 - Result 패턴 적용
  * @template T - 반환할 데이터 타입
  * @param {HttpMethod} method - HTTP 메서드
  * @param {string} url - 요청할 엔드포인트 URL
  * @param {unknown} [data] - 요청 바디 데이터 (선택적)
- * @returns {Promise<T>} - API 응답 데이터
+ * @param {Record<string, unknown>} [config] - axios 설정 (선택적)
+ * @param {ErrorHandlingOptions} [errorOptions] - 에러 처리 옵션 (선택적)
+ * @returns {Promise<Result<T>>} - 성공/실패 정보를 포함한 결과
  */
 export async function publicRequest<T>(
     method: HttpMethod,
     url: string,
     data?: unknown,
     config?: Record<string, unknown>,
-): Promise<T> {
+    errorOptions?: ErrorHandlingOptions,
+): Promise<Result<T>> {
     try {
         const response = await publicApiClient.request<T>({
             method,
@@ -127,8 +159,12 @@ export async function publicRequest<T>(
             ...config,
         });
 
-        return response.data;
+        return { success: true, data: response.data };
     } catch (error) {
-        return Promise.reject(handleError(error as AxiosError));
+        const apiError = handleError(error as AxiosError);
+
+        GlobalErrorHandler.getInstance().handleError(apiError, errorOptions);
+
+        return { success: false, error: apiError };
     }
 }

--- a/src/services/apiDeal.ts
+++ b/src/services/apiDeal.ts
@@ -14,81 +14,85 @@ import { authRequest, publicRequest } from './apiClient';
 
 // 전체 딜 목록
 export async function fetchDeals(page: number, searchRequest?: SearchRequest): Promise<FetchDealsResponse> {
-    const res = await publicRequest<FetchDealsResponse>(HttpMethod.POST, `/search/deal?page=${page}&size=40`, {
+    const result = await publicRequest<FetchDealsResponse>(HttpMethod.POST, `/search/deal?page=${page}&size=40`, {
         ...searchRequest,
     });
 
-    const cleanedDeals: FetchedDeal[] = res.deals.map((deal: FetchedDeal) => ({
-        ...deal,
-        title: cleanTitle(deal.title),
-        store: cleanStore(deal.store),
-    }));
-
-    return {
-        deals: cleanedDeals,
-        hasNext: res.hasNext,
-    };
+    if (result.success) {
+        const cleanedDeals: FetchedDeal[] = result.data.deals.map((deal: FetchedDeal) => ({
+            ...deal,
+            title: cleanTitle(deal.title),
+            store: cleanStore(deal.store),
+        }));
+        return {
+            deals: cleanedDeals,
+            hasNext: result.data.hasNext,
+        };
+    } else {
+        return { deals: [], hasNext: false };
+    }
 }
 
 // AI 추천 딜 목록
 export async function fetchRecommend(): Promise<FetchRecommendResponse> {
-    try {
-        const response = await authRequest<FetchRecommendResponse>(HttpMethod.GET, `/deal/recommend`);
+    const result = await authRequest<FetchRecommendResponse>(HttpMethod.GET, `/deal/recommend`);
 
-        return response;
-    } catch (error) {
-        console.error('AI 추천 딜 목록 조회 실패:', error);
-        throw error;
+    if (result.success) {
+        return result.data;
+    } else {
+        return {
+            deals: [],
+        };
     }
 }
 
 // 상세 딜
 export async function fetchDetailedDeal(id: string): Promise<DetailedDeal> {
-    const res = await publicRequest<DetailedDeal>(HttpMethod.GET, `/deal/${id}`);
-    const deal: DetailedDeal = res;
+    const result = await publicRequest<DetailedDeal>(HttpMethod.GET, `/deal/${id}`);
 
-    return {
-        ...deal,
-        title: cleanTitle(deal.title),
-        store: {
-            ...deal.store,
-            storeName: cleanStore(deal.store.storeName),
-        },
-    };
+    if (result.success) {
+        return {
+            ...result.data,
+            title: cleanTitle(result.data.title),
+            store: {
+                ...result.data.store,
+                storeName: cleanStore(result.data.store.storeName),
+            },
+        };
+    } else {
+        throw new Error('Failed to fetch detailed deal');
+    }
 }
 
 export async function uploadDeal(deal: UploadDeal): Promise<UploadDealResponse> {
-    try {
-        const response = await authRequest<UploadDealResponse>(HttpMethod.POST, '/deal', deal);
-
-        return response;
-    } catch (error) {
-        console.error('핫딜 업로드 실패:', error);
-        throw error;
+    const result = await authRequest<UploadDealResponse>(HttpMethod.POST, '/deal', deal);
+    if (result.success) {
+        return result.data;
+    } else {
+        throw new Error('Failed to upload deal');
     }
 }
 
 // 스토어 조회
 export async function fetchStores(): Promise<Store[]> {
-    try {
-        const response = await publicRequest<{ stores: Store[] }>(HttpMethod.GET, `/store`);
-        return response.stores;
-    } catch (error) {
-        console.error('스토어 조회 실패:', error);
-        throw error;
+    const result = await publicRequest<{ stores: Store[] }>(HttpMethod.GET, `/store`);
+    if (result.success) {
+        return result.data.stores;
+    } else {
+        return [];
     }
 }
 
 // 할인방식 조회
 export async function fetchDiscounts(): Promise<{ discountId: number; name: string }[]> {
-    try {
-        const response = await publicRequest<{ discounts: { discountId: number; name: string }[] }>(
-            HttpMethod.GET,
-            `/discount`,
-        );
-        return response.discounts;
-    } catch (error) {
-        console.error('할인방식 조회 실패:', error);
-        throw error;
+    const result = await publicRequest<{ discounts: { discountId: number; name: string }[] }>(
+        HttpMethod.GET,
+        `/discount`,
+    );
+
+    if (result.success) {
+        return result.data.discounts;
+    } else {
+        return [];
     }
 }

--- a/src/services/apiImage.ts
+++ b/src/services/apiImage.ts
@@ -15,16 +15,15 @@ export const uploadImage = async ({ images, indexes }: Images): Promise<UploadIm
         formData.append('indexes', index.toString());
     });
 
-    const response = await publicRequest<UploadImageResponse>(HttpMethod.POST, '/image', formData, {
+    const result = await publicRequest<UploadImageResponse>(HttpMethod.POST, '/image', formData, {
         headers: {
             'Content-Type': 'multipart/form-data',
         },
     });
 
-    return response;
-};
-
-export const deleteImage = async (imageId: number) => {
-    const response = await publicRequest(HttpMethod.DELETE, `/image/${imageId}`);
-    return response;
+    if (result.success) {
+        return result.data;
+    } else {
+        return [];
+    }
 };

--- a/src/services/apiSign.ts
+++ b/src/services/apiSign.ts
@@ -13,14 +13,12 @@ export const getAuthKakao = async (redirectPath: string) => {
 };
 
 export const getAuthRefresh = async (): Promise<string> => {
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const response = await publicRequest<any>(HttpMethod.GET, `/auth/refresh`);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await publicRequest<any>(HttpMethod.GET, `/auth/refresh`);
 
-        // accessToken만 꺼내서 반환
-        return response?.accessToken;
-    } catch (error) {
-        console.error('토큰 갱신 실패:', error);
-        throw error;
+    if (result.success) {
+        return result.data.accessToken;
+    } else {
+        throw new Error('Failed to get Auth refresh');
     }
 };


### PR DESCRIPTION
## 🔥 관련 이슈

- Jira 이슈: [RP-95](https://cherrypick-devteam.atlassian.net/browse/RP-95)

<br/>

## 📝 변경사항

- [x] API 요청에 공통적으로 사용할 API Client를 구현했습니다.
public한 API 요청에 대해서는 publicRequest를, 사용자 검증이 필요한 API 요청에 대해서는 authRequest를 사용합니다.
이때, API 요청이 실패한다면 해당 에러 메세지를 alert로 출력합니다.

API Client 사용 예시입니다.
```ts
export async function fetchCategories(): Promise<Category[]> {
    const result = await publicRequest<fetchCategoriesResponse>(HttpMethod.GET, '/category');
    if (result.success) {
        return result.data.categories;
    } else {
        return [];
    }
}
```

API 요청이 실패한다면 publicRequest 함수 내에서 alert로 처리가 자동으로 됩니다.
else 문에서 원하는 로직을 실행하고 데이터를 반환합니다.
Navigate 동작을 하고 싶다면 Error를 throw해서 해당 함수를 사용한 부분에서 catch한 뒤 navigate를 해주면 되겠습니다.

<br/>

## 📷 스크린샷 (선택)

<br/>

## 📋 체크리스트

- [x] Jira 이슈와 연결함
- [x] 테스트 코드를 작성했거나, 충분히 테스트했음
- [x] PR 내용과 커밋 메시지에 이슈 키 포함

<br/>

---


🙌 봐주세요! :
> 
